### PR TITLE
Update params used when calling ->sendCancelEmail

### DIFF
--- a/pmpro-failed-payment-limit.php
+++ b/pmpro-failed-payment-limit.php
@@ -62,7 +62,8 @@ function pmprofpl_pmpro_subscription_payment_failed($order) {
 		if($worked === true) {							
 			//send an email to the member
 			$myemail = new PMProEmail();
-			$myemail->sendCancelEmail($user, $old_level_id);
+			$myemail->sendCancelEmail($user);
+
 			
 			//send an email to the admin
 			$myemail = new PMProEmail();

--- a/pmpro-failed-payment-limit.php
+++ b/pmpro-failed-payment-limit.php
@@ -62,7 +62,7 @@ function pmprofpl_pmpro_subscription_payment_failed($order) {
 		if($worked === true) {							
 			//send an email to the member
 			$myemail = new PMProEmail();
-			$myemail->sendCancelEmail($user->ID);
+			$myemail->sendCancelEmail($user, $old_level_id);
 			
 			//send an email to the admin
 			$myemail = new PMProEmail();


### PR DESCRIPTION
Otherwise:
- $user as an integer is not considered, the email will not be correctly compiled
- no membership_id means "all memberships", which is not correct